### PR TITLE
Fix blobstore configs (and upload bzr & git source blobs)

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,1 +1,8 @@
---- {}
+bzr/bzr-2.7.0.tar.gz:
+  size: 11586410
+  object_id: c909e31d-5497-441b-43a1-8cd0401aef30
+  sha: sha256:0d451227b705a0dd21d8408353fe7e44d3a5069e6c4c26e5f146f1314b8fdab3
+git/git-2.21.0.tar.gz:
+  size: 8293180
+  object_id: f2b951ba-e7bd-4216-7e24-41c67d8e5934
+  sha: sha256:7a601275abcc6ff51cc79a6d402e83c90ae37d743b0b8d073aa009dd4b22d432

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,5 +1,6 @@
 name: cf-acceptance-tests
 blobstore:
-  provider: local
+  provider: s3
   options:
-    blobstore_path: /tmp/blobstore
+    bucket_name: cf-acceptance-tests-release-blobs
+    region: us-west-2

--- a/packages/bzr/packaging
+++ b/packages/bzr/packaging
@@ -2,8 +2,10 @@
 
 set -o errexit -o xtrace
 
-wget -O bzr.tgz "https://launchpad.net/bzr/2.7/2.7.0/+download/bzr-2.7.0.tar.gz"
-tar xf bzr.tgz --strip-components=1
+SRC_DIR="$(mktemp -dt bzr.XXXXXX)"
+mkdir -p "${SRC_DIR}"
+tar xf bzr/bzr-*.tar.gz --directory "${SRC_DIR}" --strip-components=1
 
+cd "${SRC_DIR}"
 source /var/vcap/packages/python-2.7/bosh/compile.env
 python2 setup.py install --prefix "${BOSH_INSTALL_TARGET}"

--- a/packages/bzr/spec
+++ b/packages/bzr/spec
@@ -4,4 +4,5 @@ name: bzr
 dependencies:
 - python-2.7
 
-files: []
+files:
+- bzr/bzr-2.7.0.tar.gz

--- a/packages/git/packaging
+++ b/packages/git/packaging
@@ -3,16 +3,9 @@
 set -o errexit
 set -o nounset
 
-VERSION=v2.21.0
-
-echo "Retrieving git ${VERSION}"
-
 SRC_DIR="$(mktemp -dt git.XXXXXX)"
 mkdir -p "${SRC_DIR}"
-url="https://github.com/git/git/archive/${VERSION}.tar.gz"
-curl -L "${url}" | tar zxf - --directory "${SRC_DIR}" --strip-components=1
-
-echo "Compiling git ${VERSION}"
+tar zxf git/git-*.tar.gz --directory "${SRC_DIR}" --strip-components=1
 
 cd "${SRC_DIR}"
 make configure

--- a/packages/git/spec
+++ b/packages/git/spec
@@ -1,3 +1,4 @@
 ---
 name: git
 files:
+- git/git-2.21.0.tar.gz


### PR DESCRIPTION
The blobstore setup was incorrectly configured to use a local blobstore; that's fine for local testing, but can't be built on non-development machines.