### PR TITLE
bin/test: Fix startup script

### DIFF
--- a/jobs/acceptance-tests/templates/test.erb
+++ b/jobs/acceptance-tests/templates/test.erb
@@ -125,6 +125,9 @@ if_p('acceptance_tests.ginkgo.nodes') do |n|
 end
 %>
 
+export GOFLAGS=-mod=vendor
+cd /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests || exit 1
+
 exec bin/test \
   <%= extra_flags %> \
   -p <%= nodes %> \


### PR DESCRIPTION
#8 broke the bin/test startup script by removing the directory change; it now continually executes itself over and over.

Also put back the `GOFLAGS` that went missing.