### PR TITLE
When calling the bash trap, make sure you respect the exit code of CATs

### DIFF
--- a/jobs/acceptance-tests/templates/test.erb
+++ b/jobs/acceptance-tests/templates/test.erb
@@ -150,9 +150,11 @@ getent hosts <%= p('acceptance_tests.apps_domain').shellescape %> \
 cf bind-staging-security-group "${loopback_secgroup}"
 cf bind-running-security-group "${loopback_secgroup}"
 cleanup() {
+    rv=$?
     cf unbind-staging-security-group "${loopback_secgroup}"
     cf unbind-running-security-group "${loopback_secgroup}"
     cf delete-security-group -f "${loopback_secgroup}"
+    exit $rv
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
otherwise CATs always appear as green in the CI.

Signed-off-by: Dimitris Karakasilis <DKarakasilis@suse.com>