### PR TITLE
Bump cf-cli to v7.0.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ git/git-2.21.0.tar.gz:
   size: 8293180
   object_id: git/git-2.21.0.tar.gz
   sha: sha256:7a601275abcc6ff51cc79a6d402e83c90ae37d743b0b8d073aa009dd4b22d432
-cf-cli-6-linux/cf-cli_6.46.1_linux_x86-64.tgz:
-  size: 8025041
-  object_id: cf-cli-6-linux/cf-cli_6.46.1_linux_x86-64.tgz
-  sha: sha256:17a54a359d23b32b791fc7c32cc72af32cff3b515866eada03a1a8b984446722
+cf-cli-7-linux/cf7-cli_7.0.1_linux_x86-64.tgz:
+  size: 9118233
+  object_id: cf-cli-7-linux/cf7-cli_7.0.1_linux_x86-64.tgz
+  sha: sha256:7f23be34b55c8b6c47ea18b41dd1fbf8b5d23ba3ac219bbc08bd80d782a8d497
 golang-1-linux/go1.12.9.linux-amd64.tar.gz:
   size: 127961523
   object_id: golang-1-linux/go1.12.9.linux-amd64.tar.gz

--- a/packages/cf-cli-6-linux/spec
+++ b/packages/cf-cli-6-linux/spec
@@ -1,4 +1,0 @@
-name: cf-cli-6-linux
-files:
-- cf-cli-6-linux/cf-cli_6.46.1_linux_x86-64.tgz
-- log-cache-cf-plugin-linux/log-cache-cf-plugin-linux-2.1.0

--- a/packages/cf-cli-7-linux/packaging
+++ b/packages/cf-cli-7-linux/packaging
@@ -2,7 +2,7 @@
 
 set -exu
 
-tar xzf cf-cli-6-linux/cf-cli_6.*_linux_x86-64.tgz
+tar xzf cf-cli-7-linux/cf7-cli_7.*_linux_x86-64.tgz
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 cp ./cf log-cache-cf-plugin-linux/log-cache-cf-plugin-linux-* ${BOSH_INSTALL_TARGET}/bin/

--- a/packages/cf-cli-7-linux/spec
+++ b/packages/cf-cli-7-linux/spec
@@ -1,0 +1,4 @@
+name: cf-cli-7-linux
+files:
+- cf-cli-7-linux/cf7-cli_7.0.1_linux_x86-64.tgz
+- log-cache-cf-plugin-linux/log-cache-cf-plugin-linux-2.1.0


### PR DESCRIPTION
Note that upstream's tgz is now called:
     cf7-cli_7.Y.Z_linux_x64.tgz
and not:
     cf-cli_7.Y.Z_linux_x64.tgz